### PR TITLE
fix: invalid Auhtorization header when no token

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ async function main() {
     const inCluster = process.env.IN_CLUSTER !== 'false';
     logger.info({inCluster}, "cluster mode configured");
     const kubeApiUrl = inCluster ? 'https://kubernetes.default.svc' : 'http://localhost:8001';
-    const token = inCluster ? await fs.readFile('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf8') : '';
+    const token = inCluster ? await fs.readFile('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf8') : undefined;
 
     const oas = await getOpenApiSpec(kubeApiUrl, token);
     const schema = await createSchema(oas, kubeApiUrl, token);

--- a/src/oas.js
+++ b/src/oas.js
@@ -12,7 +12,7 @@ module.exports = async function getOpenApiSpec(url, token) {
             baseUrl: url,
             json: true,
             timeout: 5 * 1000,
-            headers: {Authorization: `Bearer ${token}`},
+            headers: token && {Authorization: `Bearer ${token}`},
         }).then(r => {
             logger.info({url, path: p}, "successfully retrieved open api spec from this path")
             return r.body


### PR DESCRIPTION
I tried `npm run local` and found these error messages.

```
> qlkube@1.0.0 local
> IN_CLUSTER=false npm start


> qlkube@1.0.0 start
> node src/index.js

{"level":"info","time":1626317184577,"pid":7636,"hostname":"Kakao-Entui-MacBookPro.local","inCluster":false,"msg":"cluster mode configured","v":1}
{"level":"info","time":1626317184638,"pid":7636,"hostname":"Kakao-Entui-MacBookPro.local","cause":"Response code 403 (Forbidden)","url":"http://localhost:8001","path":"/swagger.json","msg":"failed to retrieve open api spec from this path - will try another","v":1}
{"level":"info","time":1626317184639,"pid":7636,"hostname":"Kakao-Entui-MacBookPro.local","cause":"Response code 403 (Forbidden)","url":"http://localhost:8001","path":"/openapi/v2","msg":"failed to retrieve open api spec from this path - will try another","v":1}
{"level":"error","time":1626317184640,"pid":7636,"hostname":"Kakao-Entui-MacBookPro.local","msg":"failed to start qlkube server","v":1}
```

It was beacuse qlkube set `"Bearer "` for `Auhtorization` header even when I dont' have a token.  Thus, I removed Authorization header setting when there's no token and it's unnecessary. This fix worked well in my environment.